### PR TITLE
change external shuffle service timeout to 1200s

### DIFF
--- a/network/shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
+++ b/network/shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
@@ -141,7 +141,7 @@ public class ExternalShuffleClient extends ShuffleClient {
     TransportClient client = clientFactory.createUnmanagedClient(host, port);
     try {
       ByteBuffer registerMessage = new RegisterExecutor(appId, execId, executorInfo).toByteBuffer();
-      client.sendRpcSync(registerMessage, 5000 /* timeoutMs */);
+      client.sendRpcSync(registerMessage, 1200000 /* timeoutMs */);
     } finally {
       client.close();
     }


### PR DESCRIPTION
Currently the shuffle service registration timeout is 5s which is hardcoded. It works well for small workloads but for heavy workload when the shuffle service is busy transferring large amount of data, we often see the executors fail to register with the shuffle service, eventually failing the job. The easiest way to solve this issue is enlarge the timeout value(e.g. 1200s), which should not bring any negative effect. These parameters have been made configurable in Apache Spark2.3.0 thru SPARK-20640.